### PR TITLE
fix bug:if no rustc installed, there will be error during start vim

### DIFF
--- a/plugins/community-pack.lua
+++ b/plugins/community-pack.lua
@@ -14,7 +14,7 @@ return {
   vim.fn.executable "npm" == 1 and { import = "astrocommunity.pack.json" } or {},
   vim.fn.executable "npm" == 1 and { import = "astrocommunity.pack.html-css" } or {},
   { import = "astrocommunity.pack.lua" },
-  vim.fn.executable "rustc" == 1 and { import = "astrocommunity.pack.rust" },
+  vim.fn.executable "rustc" == 1 and { import = "astrocommunity.pack.rust" } or {},
   vim.fn.executable "protoc" == 1 and { import = "astrocommunity.pack.proto" } or {},
   {
     "linux-cultist/venv-selector.nvim",


### PR DESCRIPTION
There will be error "Failed to load `user.plugins.community-pack`" if no rustc installed.